### PR TITLE
fix(Zarya): better vfx while using self bubble

### DIFF
--- a/src/heroes/zarya/self_bubble.opy
+++ b/src/heroes/zarya/self_bubble.opy
@@ -44,10 +44,12 @@ rule "[zarya/self_bubble.opy]: OW1 zarya self bubble cooldown":
     @Hero zarya
     @Condition eventPlayer.isUsingAbility1()
     
+    eventPlayer.disallowButton(Button.ABILITY_1)
     eventPlayer.setAbilityCharge(Button.ABILITY_1, 2)
-    eventPlayer.setAbility1Enabled(false)
     waitUntil(not eventPlayer.isUsingAbility1(), OW1_ZARYA_BUBBLE_DURATION) # wait bubble duration
+    eventPlayer.setAbility1Enabled(false)
     eventPlayer.self_bubble_cooldown = OW1_ZARYA_PARTICLE_BARRIER_COOLDOWN_TIME
+    eventPlayer.allowButton(Button.ABILITY_1)
     chase(eventPlayer.self_bubble_cooldown, 0, rate=1, ChaseReeval.NONE)
 
 


### PR DESCRIPTION
Code authored by lemonhead, commited by ecksdee

Instead of disabling the ability while bubble is active, keep it enabled, but disallow presssing the button. Final result is that the ability icon turns orange instead of red while the bubble is active.