### PR TITLE
fix(Sombra): remove passive self healing

### DIFF
--- a/src/heroes/sombra/init.opy
+++ b/src/heroes/sombra/init.opy
@@ -13,13 +13,15 @@ rule "Sombra":
     resetStats()
     resetStatuses()
     enableAllAbilities()
-    eventPlayer.setHealingDealt(1)
-    # removeSelfHealing()
+
+    removeSelfHealing()
+    eventPlayer._self_healing_percent = 0.1 # set self healing to 0.1% such that 75hp healthpack becomes 0.075hp
 
 
 rule "hacked health packs":
     @Event playerReceivedHealing
+    @Condition eventPlayer.hero_setup == Hero.SOMBRA
     @Condition eventWasHealthPack == true
-    @Condition eventHealing <= 70
     
-    heal(eventPlayer, eventPlayer, eventHealing * 99)
+    heal(eventPlayer, eventPlayer, eventHealing/unpercent(eventPlayer._self_healing_percent))
+ 

--- a/src/heroes/sombra/init.opy
+++ b/src/heroes/sombra/init.opy
@@ -23,5 +23,5 @@ rule "hacked health packs":
     @Condition eventPlayer.hero_setup == Hero.SOMBRA
     @Condition eventWasHealthPack == true
     
-    heal(eventPlayer, eventPlayer, eventHealing/unpercent(eventPlayer._self_healing_percent))
+    heal(eventPlayer, eventPlayer, eventHealing/unpercent(eventPlayer._self_healing_percent) - eventHealing)
  

--- a/src/utilities/macro_functions.opy
+++ b/src/utilities/macro_functions.opy
@@ -9,6 +9,9 @@
 # Macro function for converting decimal to percent
 #!define percent(p) (100*p)
 
+# Macro function for converting percent to decimal 
+#!define unpercent(p) (p/100)
+
 # Macro function for converting decimal to percent
 #!define roundedPercent(p) (round(percent(p)))
 


### PR DESCRIPTION
sets self healing to 0.1% so healing from hacked healthpacks can be detected