### PR TITLE
disable custom role lock rules, enable native 2/2/2 role lock

### DIFF
--- a/src/lobby/dev_lobby.opy
+++ b/src/lobby/dev_lobby.opy
@@ -18,6 +18,7 @@ settings {
         "general": {
             "heroLimit": "1PerTeam",
             "roleLimit": "2OfEachRolePerTeam",
+            "randomHeroRoleLimitPerTeam": 2,
             "gamemodeStartTrigger": "allSlotsFilled",
             "tankPassiveHealthBonus": "disabled",
             "randomHeroRoleLimitPerTeam": 2,

--- a/src/lobby/lobby.opy
+++ b/src/lobby/lobby.opy
@@ -46,6 +46,7 @@ settings {
         "general": {
             "heroLimit": "1PerTeam",
             "roleLimit": "2OfEachRolePerTeam",
+            "randomHeroRoleLimitPerTeam": 2,
             "gamemodeStartTrigger": "allSlotsFilled",
             "tankPassiveHealthBonus": "disabled",
             "randomHeroRoleLimitPerTeam": 2,

--- a/src/utilities/role_lock.opy
+++ b/src/utilities/role_lock.opy
@@ -8,18 +8,21 @@ globalvar max_roles = [
 
 
 rule "[utilities/role_lock.opy]: Skip Hero Assembly Phase":
+    @Disabled
     @Condition isAssemblingHeroes() == true
 
     setMatchTime(0.1)
 
 
 rule "[utilities/role_lock.opy]: Initialize Role Limits":
+    @Disabled
     @Event eachPlayer
 
     eventPlayer.allowed_heroes = getAllHeroes()
 
 
 rule "[utilities/role_lock.opy]: Lock/Unlock Tank heroes at role limit":
+    @Disabled
     @Event eachPlayer
     @Condition len(([player for player in getPlayers(eventPlayer.getTeam()) if player.getCurrentHero() in getTankHeroes()]).exclude(eventPlayer)) >= max_roles[0]
     @Condition max_roles[0] > 0
@@ -32,6 +35,7 @@ rule "[utilities/role_lock.opy]: Lock/Unlock Tank heroes at role limit":
 
 
 rule "[utilities/role_lock.opy]: Lock/Unlock Damage heroes at role limit":
+    @Disabled
     @Event eachPlayer
     @Condition len(([player for player in getPlayers(eventPlayer.getTeam()) if player.getCurrentHero() in getDamageHeroes()]).exclude(eventPlayer)) >= max_roles[1]
     @Condition max_roles[1] > 0
@@ -44,6 +48,7 @@ rule "[utilities/role_lock.opy]: Lock/Unlock Damage heroes at role limit":
 
 
 rule "[utilities/role_lock.opy]: Lock/Unlock Support heroes at role limit":
+    @Disabled
     @Event eachPlayer
     @Condition len(([player for player in getPlayers(eventPlayer.getTeam()) if player.getCurrentHero() in getSupportHeroes()]).exclude(eventPlayer)) >= max_roles[2]
     @Condition max_roles[2] > 0


### PR DESCRIPTION
Use @ disabled to grey out the custom role lock rules in workshop. Set random hero role limit to 2 to ensure native role lock works as intended.