### PR TITLE
new file for venture drill dash cooldown

### DIFF
--- a/src/heroes/venture/drill_dash.opy
+++ b/src/heroes/venture/drill_dash.opy
@@ -1,0 +1,10 @@
+#!mainFile "../../dev_main.opy"
+
+#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN 6
+
+rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
+    @Event eachPlayer
+    @Condition eventPlayer.hero_setup == Hero.VENTURE
+    @Condition ADJ_VENTURE_DRILL_DASH_COOLDOWN < eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
+
+    eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, 6)

--- a/src/heroes/venture/drill_dash.opy
+++ b/src/heroes/venture/drill_dash.opy
@@ -1,15 +1,30 @@
 #!mainFile "../../dev_main.opy"
 
-#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN 6
-#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED 3
+##!define ADJ_VENTURE_DRILL_DASH_COOLDOWN 6
+#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED ADJ_VENTURE_DRILL_DASH_COOLDOWN / 2
+
+playervar is_drill_dash_on_cd
+
+rule "Debug: Monitor Secondary State":
+	hudSubtext(localPlayer if localPlayer.hero_setup == Hero.VENTURE else null, "DD: {} ({})".format("ON CD" if 0 < localPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) else "READY", localPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)), HudPosition.TOP, 10, Color.AQUA, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.ALWAYS)
 
 rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
     @Event eachPlayer
-    @Condition eventPlayer.hero_setup == Hero.VENTURE
-    @Condition eventPlayer.isFiringSecondaryFire()
+	@Condition eventPlayer.getCurrentHero() == Hero.VENTURE
+    @Condition not 0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
+	eventPlayer.is_drill_dash_on_cd = true
+	waitUntil(0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE), Math.INFINITY)
+	eventPlayer.is_drill_dash_on_cd = false
 
-	waitUntil(0 < eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) and not eventPlayer.isFiringSecondaryFire(), Math.INFINITY)
+rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
+    @Event eachPlayer
+	@Condition eventPlayer.getCurrentHero() == Hero.VENTURE
+    @Condition not 0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
+	
+	printLog("Initial use of DD")
 	if eventPlayer.isUsingAbility1():
+		printLog("Burrowed, Setting DD to {}".format(ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED))
 		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED)
 	else:
+		printLog("Not Burrowed, Setting DD to {}".format(ADJ_VENTURE_DRILL_DASH_COOLDOWN))
 		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN)

--- a/src/heroes/venture/drill_dash.opy
+++ b/src/heroes/venture/drill_dash.opy
@@ -1,10 +1,15 @@
 #!mainFile "../../dev_main.opy"
 
 #!define ADJ_VENTURE_DRILL_DASH_COOLDOWN 6
+#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED 3
 
 rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
     @Event eachPlayer
     @Condition eventPlayer.hero_setup == Hero.VENTURE
-    @Condition ADJ_VENTURE_DRILL_DASH_COOLDOWN < eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
+    @Condition eventPlayer.isFiringSecondaryFire()
 
-    eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, 6)
+	waitUntil(0 < eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) and not eventPlayer.isFiringSecondaryFire(), Math.INFINITY)
+	if eventPlayer.isUsingAbility1():
+		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED)
+	else:
+		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN)

--- a/src/heroes/venture/drill_dash.opy
+++ b/src/heroes/venture/drill_dash.opy
@@ -1,11 +1,11 @@
 #!mainFile "../../dev_main.opy"
 
-#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED ADJ_VENTURE_DRILL_DASH_COOLDOWN / 2
+#!define ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED (ADJ_VENTURE_DRILL_DASH_COOLDOWN/2)
 
 rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
     @Event eachPlayer
 	@Condition eventPlayer.getCurrentHero() == Hero.VENTURE
-    @Condition not 0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
+    @Condition eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) > 0
 	
 	if eventPlayer.isUsingAbility1():
 		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED)

--- a/src/heroes/venture/drill_dash.opy
+++ b/src/heroes/venture/drill_dash.opy
@@ -1,30 +1,13 @@
 #!mainFile "../../dev_main.opy"
 
-##!define ADJ_VENTURE_DRILL_DASH_COOLDOWN 6
 #!define ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED ADJ_VENTURE_DRILL_DASH_COOLDOWN / 2
-
-playervar is_drill_dash_on_cd
-
-rule "Debug: Monitor Secondary State":
-	hudSubtext(localPlayer if localPlayer.hero_setup == Hero.VENTURE else null, "DD: {} ({})".format("ON CD" if 0 < localPlayer.getAbilityCooldown(Button.SECONDARY_FIRE) else "READY", localPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)), HudPosition.TOP, 10, Color.AQUA, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.ALWAYS)
-
-rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
-    @Event eachPlayer
-	@Condition eventPlayer.getCurrentHero() == Hero.VENTURE
-    @Condition not 0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
-	eventPlayer.is_drill_dash_on_cd = true
-	waitUntil(0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE), Math.INFINITY)
-	eventPlayer.is_drill_dash_on_cd = false
 
 rule "[venture/drill_dash.opy]: Constrain Drill Dash Cooldown":
     @Event eachPlayer
 	@Condition eventPlayer.getCurrentHero() == Hero.VENTURE
     @Condition not 0 == eventPlayer.getAbilityCooldown(Button.SECONDARY_FIRE)
 	
-	printLog("Initial use of DD")
 	if eventPlayer.isUsingAbility1():
-		printLog("Burrowed, Setting DD to {}".format(ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED))
 		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN_BURROWED)
 	else:
-		printLog("Not Burrowed, Setting DD to {}".format(ADJ_VENTURE_DRILL_DASH_COOLDOWN))
 		eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, ADJ_VENTURE_DRILL_DASH_COOLDOWN)

--- a/src/heroes/venture/init.opy
+++ b/src/heroes/venture/init.opy
@@ -13,6 +13,7 @@
 #!include "heroes/venture/excavator.opy"
 #!include "heroes/venture/tectonic_shock.opy"
 #!include "heroes/venture/burrow.opy"
+#!include "heroes/venture/drill_dash.opy"
 
 
 rule "[venture/init.opy]: Venture":


### PR DESCRIPTION
proposed fix for venture's 6 second cooldown

    - live build cd: 8
    - tested cd: 6

    this is a small patch which will constrain venture's cooldown to 6 seconds

    - new file added: venture/drill_dash.opy

    * tested with developer build (practice range)
    * tested on internal developer build
