### PR TITLE
feat(Hanzo): 125 damage per arrow

### DIFF
--- a/src/constants/adj_constants.opy
+++ b/src/constants/adj_constants.opy
@@ -89,6 +89,7 @@ globalvar SETTING_ECHO_TANK_HP = createWorkshopSetting(bool, "General Changes", 
 #!define ADJ_GENJI_ULT_COST 1932
 
 # Hanzo
+#!define ADJ_HANZO_ARROW_DAMAGE 125
 #!define ADJ_HANZO_HEALTH 200
 #!define ADJ_HANZO_STORM_COOLDOWN 10
 #!define ADJ_HANZO_STORM_DAMAGE 70

--- a/src/heroes/hanzo/init.opy
+++ b/src/heroes/hanzo/init.opy
@@ -14,9 +14,17 @@ rule "[hanzo/init.opy]: Hanzo":
     eventPlayer.call_init = false
 
 
-rule "[hanzo/init.opy]: Correct Storm Bow, Sonic Arrow and melee damage":
+rule "[hanzo/init.opy]: Correct melee damage":
     @Event playerDealtDamage
     @Condition eventPlayer.hero_setup == Hero.HANZO
-    @Condition eventAbility in [Button.PRIMARY_FIRE, Button.MELEE, Button.ABILITY_1]
-    
+    @Condition eventAbility == Button.MELEE
+
     damage(victim, attacker, ((eventDamage/eventPlayer._base_damage_scalar) - eventDamage)/eventPlayer._base_damage_scalar)
+
+
+rule "[hanzo/init.opy]: Correct Storm Bow, Sonic Arrow damage":
+    @Event playerDealtDamage
+    @Condition eventPlayer.hero_setup == Hero.HANZO
+    @Condition eventAbility in [Button.PRIMARY_FIRE, Button.ABILITY_1]
+
+    damage(victim, attacker, ((eventDamage/eventPlayer._base_damage_scalar)*(ADJ_HANZO_ARROW_DAMAGE/OW2_HANZO_ARROW_DAMAGE) - eventDamage)/eventPlayer._base_damage_scalar)


### PR DESCRIPTION
Tested against Soldier and Mei bot, deals 125 damage on body shot and 250 on headshot.
Tested echo duplicating hanzo as well.

Headshot against tanks don't work b/c of headshot passive, but bodyshot deals 125